### PR TITLE
Update SlackTime to include raw timestamp string

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # slack-go
 
-All API's should be treated as experimental until further notice
+Connect to the Slack API.
+
+# Install
+```
+go mod init
+go mod tidy
+```

--- a/conversations.go
+++ b/conversations.go
@@ -1,5 +1,0 @@
-package slack
-
-type ConversationService struct {
-	client *Client
-}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module slack-go
+
+go 1.17
+
+require github.com/kevinburke/rest v0.0.0-20210506044642-5611499aa33c

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/kevinburke/rest v0.0.0-20210506044642-5611499aa33c h1:hnbwWED5rIu+UaMkLR3JtnscMVGqp35lfzQwLuZAAUY=
+github.com/kevinburke/rest v0.0.0-20210506044642-5611499aa33c/go.mod h1:pD+iEcdAGVXld5foVN4e24zb/6fnb60tgZPZ3P/3T/I=

--- a/types.go
+++ b/types.go
@@ -7,7 +7,10 @@ import (
 	"time"
 )
 
-type SlackTime time.Time
+type SlackTime struct {
+	Time      time.Time
+	Timestamp string
+}
 
 func (s *SlackTime) UnmarshalJSON(data []byte) error {
 	var f float64
@@ -22,11 +25,14 @@ func (s *SlackTime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	intpart, divpart := math.Modf(f)
-	*s = SlackTime(time.Unix(int64(intpart), int64(divpart*100*1000*1000)))
+	*s = SlackTime{
+		Time:      time.Unix(int64(intpart), int64(divpart*100*1000*1000)),
+		Timestamp: ss,
+	}
 	return nil
 }
 
 func (s SlackTime) MarshalJSON() ([]byte, error) {
-	ts := float64(time.Time(s).Unix()) + float64(time.Time(s).UnixNano())/100*1000*1000
+	ts := float64(time.Time(s.Time).Unix()) + float64(time.Time(s.Time).UnixNano())/100*1000*1000
 	return json.Marshal(ts)
 }


### PR DESCRIPTION
This string can be used as an input in subsequent messages (via the
`thread_ts` parameter) to thread messages.
