### PR TITLE
go.mod: fix rest.NewRequestWithContext

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/meterup/slack-go
 
-go 1.17
+go 1.20
 
-require github.com/kevinburke/rest v0.0.0-20210506044642-5611499aa33c
+require github.com/kevinburke/rest v0.0.0-20230306061549-8f487d822ad0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/kevinburke/rest v0.0.0-20210506044642-5611499aa33c h1:hnbwWED5rIu+UaMkLR3JtnscMVGqp35lfzQwLuZAAUY=
-github.com/kevinburke/rest v0.0.0-20210506044642-5611499aa33c/go.mod h1:pD+iEcdAGVXld5foVN4e24zb/6fnb60tgZPZ3P/3T/I=
+github.com/kevinburke/rest v0.0.0-20230306061549-8f487d822ad0 h1:2b9anKtyO/UTUQb+TAdPAW+w0p9xCIvng4fdZJ2xsYk=
+github.com/kevinburke/rest v0.0.0-20230306061549-8f487d822ad0/go.mod h1:pD+iEcdAGVXld5foVN4e24zb/6fnb60tgZPZ3P/3T/I=


### PR DESCRIPTION
Previously we would not actually pass through the context (oops). It's possible some internal libraries also have this issue but I don't have access to the source anymore.