### PR TITLE
Add support for `chat.getPermalink`

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -17,9 +17,30 @@ type response struct {
 	Warning string    `json:"warning"`
 }
 
+type permalinkResponse struct {
+	OK        bool   `json:"ok"`
+	Channel   string `json:"channel"`
+	Permalink string `json:"permalink"`
+	Error     string `json:"error"`
+}
+
 // https://api.slack.com/methods/chat.postMessage
 func (c *ChatService) PostMessage(ctx context.Context, data url.Values) (*response, error) {
 	resp := new(response)
 	err := c.client.CreateResource(ctx, "/api/chat.postMessage", data, resp)
+	return resp, err
+}
+
+// https://api.slack.com/methods/chat.getPermalink
+//
+// `channelID` has to be the ID of the channel (C*), this endpoint does not
+// support the encoded channel names (#foo).
+func (c *ChatService) GetPermalink(ctx context.Context, channelID, messageID string) (*permalinkResponse, error) {
+	data := url.Values{
+		"channel":    []string{channelID},
+		"message_ts": []string{messageID},
+	}
+	resp := new(permalinkResponse)
+	err := c.client.CreateResource(ctx, "/api/chat.getPermalink", data, resp)
 	return resp, err
 }

--- a/http.go
+++ b/http.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kevinburke/rest/restclient"
 )
 
-const Version = "0.1"
+const Version = "0.1.1"
 
 var userAgent string
 


### PR DESCRIPTION
Add simple wrapper for `chat.getPermalink` api method.